### PR TITLE
ASR feature compatibility with spokestack-android 5.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,11 +208,11 @@ import Spokestack from "react-native-spokestack";
 // The pipeline has three required top-level keys: 'input', 'stages', and 'properties'.
 // For further examples, see https://github.com/pylon/spokestack-android#configuration
 Spokestack.initialize({
-  input: "com.pylon.spokestack.android.MicrophoneInput", // required, provides audio input into the stages
+  input: "io.spokestack.spokestack.android.MicrophoneInput", // required, provides audio input into the stages
   stages: [
-    "com.pylon.spokestack.webrtc.VoiceActivityDetector", // voice activity detection. necessary to trigger speech recognition.
-    "com.pylon.spokestack.google.GoogleSpeechRecognizer" // one of the two supplied speech recognition services
-    // 'com.pylon.spokestack.microsoft.BingSpeechRecognizer'
+    "io.spokestack.spokestack.webrtc.VoiceActivityDetector", // voice activity detection. necessary to trigger speech recognition.
+    "io.spokestack.spokestack.google.GoogleSpeechRecognizer" // one of the two supplied speech recognition services
+    // 'io.spokestack.spokestack.microsoft.BingSpeechRecognizer'
   ],
   properties: {
     "locale": "en-US",

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Spokestack.initialize({
   stages: [
     "io.spokestack.spokestack.webrtc.VoiceActivityDetector", // voice activity detection. necessary to trigger speech recognition.
     "io.spokestack.spokestack.google.GoogleSpeechRecognizer" // one of the two supplied speech recognition services
-    // 'io.spokestack.spokestack.microsoft.BingSpeechRecognizer'
+    // 'io.spokestack.spokestack.microsoft.AzureSpeechRecognizer'
   ],
   properties: {
     "locale": "en-US",

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,6 +4,7 @@ buildscript {
         mavenLocal()
         mavenCentral()
         jcenter()
+        google()
     }
 }
 
@@ -16,7 +17,7 @@ android {
     compileSdkVersion safeExtGet("compileSdkVersion", 27)
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 16)
+        minSdkVersion safeExtGet('minSdkVersion', 21)
         targetSdkVersion safeExtGet('targetSdkVersion', 27)
         versionCode 1
         versionName "1.0"
@@ -33,16 +34,18 @@ android {
 repositories {
     mavenLocal()
     mavenCentral()
+    jcenter()
+    google()
 }
 
 dependencies {
-    annotationProcessor 'com.google.auto.value:auto-value:1.2'
-    implementation('org.tensorflow:tensorflow-lite:1.12.0')
+    annotationProcessor 'com.google.auto.value:auto-value:1.5.2'
+    implementation('org.tensorflow:tensorflow-lite:1.14.0')
     implementation('com.github.wendykierp:JTransforms:3.0')
-    implementation 'io.grpc:grpc-okhttp:1.16.1'
+    implementation 'io.grpc:grpc-okhttp:1.28.1'
     implementation 'com.google.code.gson:gson:2.8.5'
-    implementation 'com.google.cloud:google-cloud-speech:0.69.0-beta'
+    implementation 'com.google.cloud:google-cloud-speech:1.20.0' // NB 1.21+ fails at either build or runtime.
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.pylon:spokestack:2.0.1'
+    implementation 'io.spokestack:spokestack-android:5.2.0'
 }
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.pylon.RNSpokestack">
+    package="com.pylon.RNSpokestack"
+    android:name="androidx.multidex.MultiDexApplication">
+
 
 </manifest>
   

--- a/android/src/main/java/com/pylon/RNSpokestack/RNSpokestackModule.java
+++ b/android/src/main/java/com/pylon/RNSpokestack/RNSpokestackModule.java
@@ -1,26 +1,19 @@
 
 package com.pylon.RNSpokestack;
 
-import com.pylon.spokestack.SpeechPipeline;
-import com.pylon.spokestack.SpeechContext;
-import com.pylon.spokestack.SpeechConfig;
-import com.pylon.spokestack.OnSpeechEventListener;
+import io.spokestack.spokestack.SpeechPipeline;
+import io.spokestack.spokestack.SpeechContext;
+import io.spokestack.spokestack.OnSpeechEventListener;
 
-import android.os.Bundle;
-import android.os.Handler;
 import android.util.Log;
-import java.util.Locale;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.ReadableMapKeySetIterator;
-import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 
-import java.util.ArrayList;
 import java.util.Map;
 import javax.annotation.Nullable;
 


### PR DESCRIPTION
Updates dependencies and code for ASR compatibility with the latest release of `spokestack-android`. TTS and NLU Android support will be added in a later PR.

A special note regarding the `google-cloud-speech` dependency: in testing, versions later than `1.20.0` were not compatible with `react-native: 0.62.2`. 