### PR TITLE
fix: nullable slot values in objc nlu interop

### DIFF
--- a/ios/RNSpokestack.m
+++ b/ios/RNSpokestack.m
@@ -171,7 +171,7 @@ RCT_EXPORT_MODULE();
         // convert the typed slot dictionary into a simple dictionary of string keys and values
         NSMutableDictionary *slots = [[NSMutableDictionary alloc] init];
         [result.slots enumerateKeysAndObjectsUsingBlock:^(NSString *name, Slot *slot, BOOL *stop) {
-            slots[name] = @{@"type": slot.type, @"value": slot.value, @"rawValue": slot.rawValue};
+            slots[name] = @{@"type": slot.type, @"value": (slot.value ?: [NSNull null]), @"rawValue": (slot.rawValue  ?: [NSNull null])};
         }];
         // send the slots along with the rest of the result object
         [self sendEventWithName:@"onNLUEvent" body: @{@"event": @"classification", @"result": @{@"intent":result.intent, @"confidence":[[NSNumber numberWithFloat:result.confidence] stringValue], @"slots":slots}, @"error":@""}];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-spokestack",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "React Native wrapper for Spokestack",
   "main": "index.js",
   "author": "Noel Weichbrodt <noel@spokestack.io>",


### PR DESCRIPTION
https://nshipster.com/nil/

fixes an exception like
```
 *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[1]'
```