### PR TITLE
fix: propagate NLU types from android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,5 +52,5 @@ dependencies {
     implementation 'io.grpc:grpc-okhttp:1.28.1'
     implementation 'com.google.cloud:google-cloud-speech:1.20.0' // NB 1.21+ fails at either build or runtime.
     implementation 'com.facebook.react:react-native:+'
-    implementation 'io.spokestack:spokestack-android:6.0.0'
+    implementation 'io.spokestack:spokestack-android:7.0.0'
 }

--- a/android/src/main/java/io/spokestack/RNSpokestack/RNSpokestackModule.java
+++ b/android/src/main/java/io/spokestack/RNSpokestack/RNSpokestackModule.java
@@ -163,11 +163,11 @@ public class RNSpokestackModule extends ReactContextBaseJavaModule implements On
         Map<String, Object> result = new HashMap<>();
         Map<String, Object> slots = new HashMap<>();
         for (Map.Entry<String, Slot> entry : nluResult.getSlots().entrySet()) {
-            Map<String, String> slot = new HashMap<>();
+            Map<String, Object> slot = new HashMap<>();
             Slot s = entry.getValue();
-            slot.put("type", s.getName());
+            slot.put("type", s.getType());
             Object val = s.getValue();
-            String value = (val == null) ? null : val.toString();
+            Object value = isPrimitive(val) ? val : val.toString();
             slot.put("value", value);
             slot.put("rawValue", s.getRawValue());
             slots.put(entry.getKey(), slot);
@@ -178,6 +178,17 @@ public class RNSpokestackModule extends ReactContextBaseJavaModule implements On
         eventMap.put("result", result);
         eventMap.put("event", "classification");
         return eventMap;
+    }
+
+    private static boolean isPrimitive(Object val) {
+        return val == null
+            || val instanceof Boolean
+            || val instanceof Double
+            || val instanceof Float
+            || val instanceof Integer
+            || val instanceof Long
+            || val instanceof Short
+            || val instanceof String;
     }
 
     @Override

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Noel Weichbrodt <noel@spokestack.io>",
   "types": "react-native-spokestack.d.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "cd android && gradle test"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
This uses a new feature in the Android library to properly
set the types of NLU slots it returns, also maintaining proper types on
slots that can be expressed as JS primitives and stringifying others.