### PR TITLE
Simplify config API by using new native turnkey builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,9 @@ React Native wrapper for the [Spokestack](https://spokestack.io) speech activity
 | onStop(event)             | `null`                | Invoked when the speech pipeline has been stopped                                                                    | Android, iOS |
 | onRecognize(event)        | `transcript`:`string` | Invoked when speech has been recognized                                                                              | Android, iOS |
 | onTimeout(event)          | `null`                | Invoked when no speech has been detected for `wake-active-max` after activation                                      | Android, iOS |
-| onTrace(event)            | `message`:`string`    | Invoked when a trace message become available                                                                        | Android      |
-| onError(event)            | `error`:`string`      | Invoked upon an error in the speech pipeline execution                                                               | Android, iOS |
+| onTrace(event)            | `message`:`string`    | Invoked when a trace message becomes available                                                                       | Android      |
+| onError(event)            | `error`:`string`      | Invoked upon an error in a Spokestack module.                                                                        | Android, iOS |
 | onSuccess(ttsEvent)          | `url`:`string`   | Invoked upon a successful TTS synthesis request                | iOS          |
-| onFailure(ttsEvent)          | `error`:`string` | Invoked upon a failed TTS synthesis request                    | iOS          |
 | onClassification(nluEvent) | `result`:`dictionary` | Invoked upon a successful NLU utterance classification | iOS          |
 
 ### Dictionaries

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ React Native wrapper for the [Spokestack](https://spokestack.io) speech activity
 `$ npm install react-native-spokestack --save`
 
 - _React Native_: 0.60.0+
-- _Android_: Android SDK 26+
+- _Android_: Android SDK 24+
 - _iOS_: iOS 13+
 
 ## Usage
@@ -109,7 +109,7 @@ React Native wrapper for the [Spokestack](https://spokestack.io) speech activity
 
 ### Android
 
-- Requires Android SDK 26 level support
+- Requires Android SDK 24 level support
 - Requires Gradle 3.0.1+ (`classpath 'com.android.tools.build:gradle:3.0.1'` in root `build.gradle` `dependencies`)
 - Add app setting for microphone permission
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ React Native wrapper for the [Spokestack](https://spokestack.io) speech activity
 | SSML           | 1     |
 | SPEECHMARKDOWN | 2     |
 
+#### Pipeline Profiles
+| PipelineProfile                      | Value |
+| ------------------------------------ | ----- |
+| TFLITE_WAKEWORD_NATIVE_ASR           |     0  |
+| VAD_NATIVE_ASR                        |     1 |
+| PTT_NATIVE_ASR                        |     2 |
+| TFLITE_WAKEWORD_SPOKESTACK_ASR        |     3 |
+| VAD_SPOKESTACK_ASR                   |     4 |
+| PTT_SPOKESTACK_ASR                   |     5 |
+
+
 ## Gotchas
 
 ### Android

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ React Native wrapper for the [Spokestack](https://spokestack.io) speech activity
 | type       | string |
 | value      | string |
 
-
 ### Enums
 #### Trace
 

--- a/RNSpokestack.podspec
+++ b/RNSpokestack.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.static_framework = true
 
-  s.dependency "Spokestack-iOS", "13.1.4"
+  s.dependency "Spokestack-iOS", "14.0.0o"
   s.dependency 'React'
 end

--- a/RNSpokestack.podspec
+++ b/RNSpokestack.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.static_framework = true
 
-  s.dependency "Spokestack-iOS", "14.0.0o"
+  s.dependency "Spokestack-iOS", "14.0.1"
   s.dependency 'React'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,7 +46,7 @@ repositories {
 dependencies {
     testImplementation 'junit:junit:4.12'
     annotationProcessor 'com.google.auto.value:auto-value:1.5.2'
-    implementation 'org.tensorflow:tensorflow-lite:1.15.0'
+    implementation 'org.tensorflow:tensorflow-lite:2.3.0'
     implementation 'com.github.wendykierp:JTransforms:3.0'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'io.grpc:grpc-okhttp:1.28.1'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,7 @@ android {
     compileSdkVersion safeExtGet("compileSdkVersion", 27)
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 21)
+        minSdkVersion safeExtGet('minSdkVersion', 24)
         targetSdkVersion safeExtGet('targetSdkVersion', 27)
         versionCode 1
         versionName "1.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.1.0'
     }
 }
 
@@ -46,11 +46,11 @@ repositories {
 dependencies {
     testImplementation 'junit:junit:4.12'
     annotationProcessor 'com.google.auto.value:auto-value:1.5.2'
-    implementation 'org.tensorflow:tensorflow-lite:1.14.0'
+    implementation 'org.tensorflow:tensorflow-lite:1.15.0'
     implementation 'com.github.wendykierp:JTransforms:3.0'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'io.grpc:grpc-okhttp:1.28.1'
     implementation 'com.google.cloud:google-cloud-speech:1.20.0' // NB 1.21+ fails at either build or runtime.
     implementation 'com.facebook.react:react-native:+'
-    implementation 'io.spokestack:spokestack-android:8.1.0'
+    implementation 'io.spokestack:spokestack-android:9.1.0'
 }

--- a/android/src/main/java/io/spokestack/RNSpokestack/RNSpokestackAdapter.java
+++ b/android/src/main/java/io/spokestack/RNSpokestack/RNSpokestackAdapter.java
@@ -9,15 +9,18 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiFunction;
 
-import androidx.annotation.RequiresApi;
 import io.spokestack.spokestack.nlu.NLUResult;
 import io.spokestack.spokestack.nlu.Slot;
 import io.spokestack.spokestack.tts.TTSEvent;
 import io.spokestack.spokestack.util.EventTracer;
 
-@RequiresApi(api = Build.VERSION_CODES.N)
 public class RNSpokestackAdapter extends io.spokestack.spokestack.SpokestackAdapter {
-    public BiFunction<String, WritableMap, Void> sendEvent;
+
+    private BiFunction<String, WritableMap, Void> sendEvent;
+
+    public RNSpokestackAdapter(BiFunction<String, WritableMap, Void> sendFunc) {
+        sendEvent = sendFunc;
+    }
 
     @Override
     public void onTrace(EventTracer.Level level, String message) {

--- a/android/src/main/java/io/spokestack/RNSpokestack/RNSpokestackAdapter.java
+++ b/android/src/main/java/io/spokestack/RNSpokestack/RNSpokestackAdapter.java
@@ -1,0 +1,91 @@
+package io.spokestack.RNSpokestack;
+
+import android.os.Build;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import androidx.annotation.RequiresApi;
+import io.spokestack.spokestack.nlu.NLUResult;
+import io.spokestack.spokestack.nlu.Slot;
+import io.spokestack.spokestack.tts.TTSEvent;
+import io.spokestack.spokestack.util.EventTracer;
+
+@RequiresApi(api = Build.VERSION_CODES.N)
+public class RNSpokestackAdapter extends io.spokestack.spokestack.SpokestackAdapter {
+    public BiFunction<String, WritableMap, Void> sendEvent;
+
+    @Override
+    public void onTrace(EventTracer.Level level, String message) {
+        WritableMap react_event = Arguments.createMap();
+        react_event.putString("event", "trace");
+        react_event.putString("trace", message);
+        react_event.putString("level", level.toString());
+        sendEvent.apply("onSpeechEvent", react_event);
+    }
+
+    @Override
+    public void eventReceived(TTSEvent event) {
+        WritableMap react_event = Arguments.createMap();
+        if (event.getError() == null) {
+            react_event.putString("event", "success");
+            react_event.putString("url", event.getTtsResponse().getAudioUri().toString());
+            sendEvent.apply("onTTSEvent", react_event);
+        } else {
+            react_event.putString("event", "failure");
+            react_event.putString("error", event.getError().getLocalizedMessage());
+            sendEvent.apply("onErrorEvent", react_event);
+        }
+    }
+
+    @Override
+    public void onError(Throwable err) {
+        WritableMap react_event = Arguments.createMap();
+        react_event.putString("event", "error");
+        react_event.putString("error", err.getLocalizedMessage());
+        sendEvent.apply("onErrorEvent", react_event);
+    }
+
+    @Override
+    public void call(NLUResult arg) {
+        WritableMap reactEvent = Arguments.makeNativeMap(toEvent(arg));
+        sendEvent.apply("onNLUEvent", reactEvent);
+    }
+
+    static Map<String, Object> toEvent(NLUResult nluResult) {
+        Map<String, Object> eventMap = new HashMap<>();
+        Map<String, Object> result = new HashMap<>();
+        Map<String, Object> slots = new HashMap<>();
+        for (Map.Entry<String, Slot> entry : nluResult.getSlots().entrySet()) {
+            Map<String, Object> slot = new HashMap<>();
+            Slot s = entry.getValue();
+            slot.put("type", s.getType());
+            Object val = s.getValue();
+            Object value = isPrimitive(val) ? val : val.toString();
+            slot.put("value", value);
+            slot.put("rawValue", s.getRawValue());
+            slots.put(entry.getKey(), slot);
+        }
+        result.put("intent", nluResult.getIntent());
+        result.put("confidence", Float.toString(nluResult.getConfidence()));
+        result.put("slots", slots);
+        eventMap.put("result", result);
+        eventMap.put("event", "classification");
+        return eventMap;
+    }
+
+    private static boolean isPrimitive(Object val) {
+        return val == null
+                || val instanceof Boolean
+                || val instanceof Double
+                || val instanceof Float
+                || val instanceof Integer
+                || val instanceof Long
+                || val instanceof Short
+                || val instanceof String;
+    }
+}

--- a/android/src/main/java/io/spokestack/RNSpokestack/RNSpokestackModule.java
+++ b/android/src/main/java/io/spokestack/RNSpokestack/RNSpokestackModule.java
@@ -1,8 +1,6 @@
 
 package io.spokestack.RNSpokestack;
 
-import android.os.Build;
-
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -101,6 +99,9 @@ public class RNSpokestackModule extends ReactContextBaseJavaModule {
         builder.withoutAutoPlayback();
 
         spokestack = builder.build();
+        WritableMap react_event = Arguments.createMap();
+        react_event.putString("event", "init");
+        sendEvent("init", react_event);
     }
 
     private enum PipelineProfiles {

--- a/android/src/main/java/io/spokestack/RNSpokestack/RNSpokestackModule.java
+++ b/android/src/main/java/io/spokestack/RNSpokestack/RNSpokestackModule.java
@@ -118,7 +118,7 @@ public class RNSpokestackModule extends ReactContextBaseJavaModule {
         }
 
         public String value() {
-            return this.profile.getCanonicalName();
+            return this.profile.getName();
         }
     }
 

--- a/android/src/main/java/io/spokestack/RNSpokestack/RNSpokestackModule.java
+++ b/android/src/main/java/io/spokestack/RNSpokestack/RNSpokestackModule.java
@@ -196,7 +196,7 @@ public class RNSpokestackModule extends ReactContextBaseJavaModule implements On
         WritableMap react_event = Arguments.createMap();
         react_event.putString("event", "error");
         react_event.putString("error", err.getLocalizedMessage());
-        sendEvent("onNLUEvent", react_event);
+        sendEvent("onErrorEvent", react_event);
     }
 
     public void onEvent(SpeechContext.Event event, SpeechContext context) {
@@ -205,7 +205,11 @@ public class RNSpokestackModule extends ReactContextBaseJavaModule implements On
         react_event.putString("transcript", context.getTranscript());
         react_event.putString("message", context.getMessage());
         react_event.putString("error", Log.getStackTraceString(context.getError()));
-        sendEvent("onSpeechEvent", react_event);
+        if (react_event.getString("error").isEmpty()) {
+            sendEvent("onSpeechEvent", react_event);
+        } else {
+            sendEvent("onErrorEvent", react_event);
+        }
     }
 
     public void onEvent(String event, Boolean active) {
@@ -232,10 +236,11 @@ public class RNSpokestackModule extends ReactContextBaseJavaModule implements On
         if (event.getError() == null) {
             react_event.putString("event", "success");
             react_event.putString("url", event.getTtsResponse().getAudioUri().toString());
+            sendEvent("onTTSEvent", react_event);
         } else {
             react_event.putString("event", "failure");
-            react_event.putString("error" , event.getError().getLocalizedMessage());
+            react_event.putString("error", event.getError().getLocalizedMessage());
+            sendEvent("onErrorEvent", react_event);
         }
-        sendEvent("onTTSEvent", react_event);
     }
 }

--- a/index.js
+++ b/index.js
@@ -140,11 +140,6 @@ class Spokestack {
           this.onRecognize(e)
         }
         break
-      case 'trace':
-        if (this.onTrace) {
-          this.onTrace(e)
-        }
-        break
       case 'start':
         if (this.onStart) {
           this.onStart(e)
@@ -155,8 +150,7 @@ class Spokestack {
           this.onStop(e)
         }
         break
-    case 'init':
-      console.log("rns init")
+      case 'init':
         if (this.onInit) {
           this.onInit(e)
         }

--- a/index.js
+++ b/index.js
@@ -51,7 +51,8 @@ class Spokestack {
       'onSpeechEvent': this._onSpeechEvent.bind(this),
       'onTTSEvent': this._onTTSEvent.bind(this),
       'onNLUEvent': this._onNLUEvent.bind(this),
-      'onErrorEvent': this._onErrorEvent.bind(this)
+      'onErrorEvent': this._onErrorEvent.bind(this),
+      'onTraceEvent': this._onTraceEvent.bind(this)
     }
   }
 
@@ -103,6 +104,12 @@ class Spokestack {
     }
   }
 
+  _onTraceEvent (e) {
+    if (this.onTrace) {
+      this.onTrace(e)
+    }
+  }
+
   _onNLUEvent (e) {
     console.log('js onNLUEvent ' + e.event)
     if (this.onClassification) {
@@ -148,7 +155,8 @@ class Spokestack {
           this.onStop(e)
         }
         break
-      case 'init':
+    case 'init':
+      console.log("rns init")
         if (this.onInit) {
           this.onInit(e)
         }

--- a/index.js
+++ b/index.js
@@ -19,6 +19,16 @@ const TTSFormat = Object.freeze({
   SPEECHMARKDOWN: 2
 })
 
+// Warning: Order is fixed for interop with Spokestack-iOS. New profiles should be appended to end and coordinated with Spokestack-iOS releases.
+const PipelineProfile = Object.freeze({
+  TFLITE_WAKEWORD_NATIVE_ASR: 0,
+  VAD_NATIVE_ASR: 1,
+  PTT_NATIVE_ASR: 2,
+  TFLITE_WAKEWORD_SPOKESTACK_ASR: 3,
+  VAD_SPOKESTACK_ASR: 4,
+  PTT_SPOKESTACK_ASR: 5
+})
+
 class Spokestack {
   get TraceLevel () {
     return TraceLevel
@@ -26,6 +36,10 @@ class Spokestack {
 
   get TTSFormat () {
     return TTSFormat
+  }
+
+  get PipelineProfile() {
+    return PipelineProfile
   }
 
   // Class methods
@@ -36,7 +50,8 @@ class Spokestack {
     this._events = {
       'onSpeechEvent': this._onSpeechEvent.bind(this),
       'onTTSEvent': this._onTTSEvent.bind(this),
-      'onNLUEvent': this._onNLUEvent.bind(this)
+      'onNLUEvent': this._onNLUEvent.bind(this),
+      'onErrorEvent': this._onErrorEvent.bind(this)
     }
   }
 
@@ -82,38 +97,22 @@ class Spokestack {
 
   // Events
 
+  _onErrorEvent (e) {
+    if (this.onError) {
+      this.onError(e)
+    }
+  }
+
   _onNLUEvent (e) {
     console.log('js onNLUEvent ' + e.event)
-    switch (e.event.toLowerCase()) {
-      case 'classification':
-        if (this.onClassification) {
-          this.onClassification(e)
-        }
-        break
-      case 'error':
-        if (this.onError) {
-          this.onError(e)
-        }
-        break
-      default:
-        break
+    if (this.onClassification) {
+      this.onClassification(e)
     }
   }
 
   _onTTSEvent (e) {
-    switch (e.event.toLowerCase()) {
-      case 'success':
-        if (this.onSuccess) {
-          this.onSuccess(e)
-        }
-        break
-      case 'failure':
-        if (this.onFailure) {
-          this.onFailure(e)
-        }
-        break
-      default:
-        break
+    if (this.onSuccess) {
+      this.onSuccess(e)
     }
   }
 
@@ -137,11 +136,6 @@ class Spokestack {
       case 'trace':
         if (this.onTrace) {
           this.onTrace(e)
-        }
-        break
-      case 'error':
-        if (this.onError) {
-          this.onError(e)
         }
         break
       case 'start':

--- a/ios/RNSpokestack.h
+++ b/ios/RNSpokestack.h
@@ -15,8 +15,6 @@ API_AVAILABLE(ios(13.0))
 @property (nonatomic) SpeechPipeline *pipeline;
 @property (nonatomic) TextToSpeech *tts;
 @property (nonatomic) NLUTensorflow *nlu;
-@property (nonatomic) id <SpeechProcessor> asrService;
-@property (nonatomic) id <SpeechProcessor> wakewordService;
 @property (nonatomic) SpeechConfiguration *speechConfig;
 @property (nonatomic) SpeechContext *speechContext;
 @end

--- a/ios/RNSpokestack.h
+++ b/ios/RNSpokestack.h
@@ -11,7 +11,7 @@
 #import <Spokestack/Spokestack-Swift.h>
 
 API_AVAILABLE(ios(13.0))
-@interface RNSpokestack : RCTEventEmitter <RCTBridgeModule, SpeechEventListener, TextToSpeechDelegate, NLUDelegate>
+@interface RNSpokestack : RCTEventEmitter <RCTBridgeModule, SpokestackDelegate>
 @property (nonatomic) SpeechPipeline *pipeline;
 @property (nonatomic) TextToSpeech *tts;
 @property (nonatomic) NLUTensorflow *nlu;

--- a/ios/RNSpokestack.m
+++ b/ios/RNSpokestack.m
@@ -44,7 +44,7 @@ RCT_EXPORT_MODULE();
 
 - (NSArray<NSString *> *)supportedEvents
 {
-    return @[@"onSpeechEvent", @"onTTSEvent", @"onNLUEvent", @"onErrorEvent"];
+    return @[@"onSpeechEvent", @"onTTSEvent", @"onNLUEvent", @"onErrorEvent", @"onTraceEvent"];
 }
 
 - (void)didActivate {
@@ -52,7 +52,7 @@ RCT_EXPORT_MODULE();
     if (hasListeners)
     {
         [self sendEventWithName:@"onSpeechEvent" body:@{
-            @"event": @"activate", @"transcript": @"", @"error": @""}];
+            @"event": @"activate", @"transcript": @""}];
     }
 }
 
@@ -61,7 +61,7 @@ RCT_EXPORT_MODULE();
     if (hasListeners)
     {
         [self sendEventWithName:@"onSpeechEvent" body:@{
-            @"event": @"deactivate", @"transcript": @"", @"error": @""}];
+            @"event": @"deactivate", @"transcript": @""}];
     }
 }
 
@@ -69,8 +69,8 @@ RCT_EXPORT_MODULE();
     NSLog(@"RNSpokestack didTrace");
     if (hasListeners)
     {
-        [self sendEventWithName:@"onSpeechEvent" body:@{
-            @"event": @"trace", @"transcript": @"", @"error": @"", @"trace": trace}];
+        [self sendEventWithName:@"onTraceEvent" body:@{
+            @"event": @"trace", @"trace": trace}];
     }
 }
 
@@ -79,7 +79,7 @@ RCT_EXPORT_MODULE();
     if (hasListeners)
     {
         [self sendEventWithName:@"onSpeechEvent" body:@{
-            @"event": @"stop", @"transcript": @"", @"error": @""}];
+            @"event": @"stop", @"transcript": @""}];
     }
 }
 
@@ -88,7 +88,7 @@ RCT_EXPORT_MODULE();
     if (hasListeners)
     {
         [self sendEventWithName:@"onSpeechEvent" body:@{
-            @"event": @"start", @"transcript": @"", @"error": @""}];
+            @"event": @"start", @"transcript": @""}];
     }
 }
 
@@ -97,7 +97,7 @@ RCT_EXPORT_MODULE();
     if (hasListeners)
     {
         [self sendEventWithName:@"onSpeechEvent" body:@{
-            @"event": @"recognize", @"transcript": results.transcript, @"error": @""}];
+            @"event": @"recognize", @"transcript": results.transcript}];
     }
 }
 
@@ -106,7 +106,7 @@ RCT_EXPORT_MODULE();
     if (hasListeners)
     {
         [self sendEventWithName:@"onSpeechEvent" body:@{
-            @"event": @"timeout", @"transcript": @"", @"error": @""}];
+            @"event": @"timeout", @"transcript": @""}];
     }
 }
 
@@ -114,8 +114,8 @@ RCT_EXPORT_MODULE();
     NSLog(@"RNSpokestack setupFailed");
     if (hasListeners)
     {
-        [self sendEventWithName:@"onSpeechEvent" body:@{
-            @"event": @"error", @"transcript": @"", @"error": error}];
+        [self sendEventWithName:@"onErrorEvent" body:@{
+            @"event": @"error", @"error": error}];
     }
 }
 
@@ -124,7 +124,7 @@ RCT_EXPORT_MODULE();
     if (hasListeners)
     {
         [self sendEventWithName:@"onSpeechEvent" body:@{
-            @"event": @"init", @"transcript": @"", @"error": @""}];
+            @"event": @"init", @"transcript": @""}];
     }
 }
 
@@ -145,7 +145,7 @@ RCT_EXPORT_MODULE();
     if (hasListeners)
     {
         [self sendEventWithName:@"onTTSEvent" body:@{
-            @"event": @"success", @"url": result.url.absoluteString, @"error": @""}];
+            @"event": @"success", @"url": result.url.absoluteString}];
     }
 }
 
@@ -161,7 +161,7 @@ RCT_EXPORT_MODULE();
             slots[name] = @{@"type": slot.type, @"value": (slot.value ?: [NSNull null]), @"rawValue": (slot.rawValue  ?: [NSNull null])};
         }];
         // send the slots along with the rest of the result object
-        [self sendEventWithName:@"onNLUEvent" body: @{@"event": @"classification", @"result": @{@"intent":result.intent, @"confidence":[[NSNumber numberWithFloat:result.confidence] stringValue], @"slots":slots}, @"error":@""}];
+        [self sendEventWithName:@"onNLUEvent" body: @{@"event": @"classification", @"result": @{@"intent":result.intent, @"confidence":[[NSNumber numberWithFloat:result.confidence] stringValue], @"slots":slots}}];
     }
 }
 

--- a/ios/RNSpokestack.m
+++ b/ios/RNSpokestack.m
@@ -178,13 +178,11 @@ RCT_EXPORT_METHOD(initialize:(NSDictionary *)config)
 
     NSError *error;
 
-    self.speechConfig.tracing = ([config valueForKeyPath:@"properties.trace-level"]) ? [RCTConvert NSInteger:[config valueForKeyPath:@"properties.trace-level"]] : self.speechConfig.tracing;
-
     /// MARK: Speech
 
     self.speechConfig.vadFallDelay = ([config valueForKeyPath:@"pipeline.vad-fall-delay"]) ? [RCTConvert NSInteger:[config valueForKeyPath:@"pipeline.vad-fall-delay"]] : self.speechConfig.vadFallDelay;
     
-    /// MARK: Wakeword signal processing
+    /// MARK: Wakeword
 
     self.speechConfig.rmsTarget = ([config valueForKeyPath:@"pipeline.rms-target"]) ? [[RCTConvert NSNumber:[config valueForKeyPath:@"pipeline.rms-target"]] floatValue] : self.speechConfig.rmsTarget;
     self.speechConfig.rmsAlpha = ([config valueForKeyPath:@"pipeline.rms-alpha"]) ? [[RCTConvert NSNumber:[config valueForKeyPath:@"pipeline.rms-alpha"]] floatValue] : self.speechConfig.rmsAlpha;
@@ -199,27 +197,20 @@ RCT_EXPORT_METHOD(initialize:(NSDictionary *)config)
     self.speechConfig.wakeActiveMax = ([config valueForKeyPath:@"pipeline.wake-active-max"]) ? [RCTConvert NSInteger:[config valueForKeyPath:@"pipeline.wake-active-max"]] : self.speechConfig.wakeActiveMax;
     self.speechConfig.frameWidth = ([config valueForKeyPath:@"pipeline.frame-width"]) ? [RCTConvert NSInteger:[config valueForKeyPath:@"pipeline.frame-width"]] : self.speechConfig.frameWidth;
     self.speechConfig.preEmphasis = ([config valueForKeyPath:@"pipeline.pre-emphasis"]) ? [[RCTConvert NSNumber:[config valueForKeyPath:@"pipeline.pre-emphasis"]] floatValue] : self.speechConfig.preEmphasis;
+    self.speechConfig.filterModelPath = ([config valueForKeyPath:@"pipeline.wake-filter-path"]) ? [RCTConvert NSString:[config valueForKeyPath:@"pipeline.wake-filter-path"]] : self.speechConfig.filterModelPath;
+    self.speechConfig.encodeModelPath = ([config valueForKeyPath:@"pipeline.wake-encode-path"]) ? [RCTConvert NSString:[config valueForKeyPath:@"pipeline.wake-encode-path"]] : self.speechConfig.encodeModelPath;
+    self.speechConfig.detectModelPath = ([config valueForKeyPath:@"pipeline.wake-detect-path"]) ? [RCTConvert NSString:[config valueForKeyPath:@"pipeline.wake-detect-path"]] : self.speechConfig.detectModelPath;
+    self.speechConfig.wakeThreshold = ([config valueForKeyPath:@"pipeline.wake-threshold"]) ? [[RCTConvert NSNumber:[config valueForKeyPath:@"pipeline.wake-threshold"]] floatValue] : self.speechConfig.wakeThreshold;
+    self.speechConfig.wakewords = ([config valueForKeyPath:@"properties.wakewords"]) ? [RCTConvert NSString:[config valueForKeyPath:@"properties.wakewords"]] : self.speechConfig.wakewords;
+    self.speechConfig.wakewordRequestTimeout = ([config valueForKeyPath:@"properties.wake-request-timeout"]) ? [RCTConvert NSInteger:[config valueForKeyPath:@"properties.wake-request-timeout"]] : self.speechConfig.wakewordRequestTimeout;
 
-    /// MARK: Wakeword models
+    /// MARK: Spokestack configuration
 
-    // TFLite
-    if ([[config valueForKey:@"stages"] containsObject:@"io.spokestack.spokestack.wakeword.WakewordTrigger"]) {
-        self.speechConfig.filterModelPath = ([config valueForKeyPath:@"pipeline.wake-filter-path"]) ? [RCTConvert NSString:[config valueForKeyPath:@"pipeline.wake-filter-path"]] : self.speechConfig.filterModelPath;
-        self.speechConfig.encodeModelPath = ([config valueForKeyPath:@"pipeline.wake-encode-path"]) ? [RCTConvert NSString:[config valueForKeyPath:@"pipeline.wake-encode-path"]] : self.speechConfig.encodeModelPath;
-        self.speechConfig.detectModelPath = ([config valueForKeyPath:@"pipeline.wake-detect-path"]) ? [RCTConvert NSString:[config valueForKeyPath:@"pipeline.wake-detect-path"]] : self.speechConfig.detectModelPath;
-        self.speechConfig.wakeThreshold = ([config valueForKeyPath:@"pipeline.wake-threshold"]) ? [[RCTConvert NSNumber:[config valueForKeyPath:@"pipeline.wake-threshold"]] floatValue] : self.speechConfig.wakeThreshold;
-    // Apple ASR
-    } else {
-        self.speechConfig.wakewords = ([config valueForKeyPath:@"properties.wakewords"]) ? [RCTConvert NSString:[config valueForKeyPath:@"properties.wakewords"]] : self.speechConfig.wakewords;
-        self.speechConfig.wakewordRequestTimeout = ([config valueForKeyPath:@"properties.wake-request-timeout"]) ? [RCTConvert NSInteger:[config valueForKeyPath:@"properties.wake-request-timeout"]] : self.speechConfig.wakewordRequestTimeout;
-    }
-
-    /// MARK: TTS configuration
-
+    self.speechConfig.tracing = ([config valueForKeyPath:@"properties.trace-level"]) ? [RCTConvert NSInteger:[config valueForKeyPath:@"properties.trace-level"]] : self.speechConfig.tracing;
     self.speechConfig.apiId = ([config valueForKeyPath:@"properties.api-id"]) ? [RCTConvert NSString:[config valueForKeyPath:@"properties.api-id"]] : self.speechConfig.apiId;
     self.speechConfig.apiSecret = ([config valueForKeyPath:@"properties.api-id"]) ? [RCTConvert NSString:[config valueForKeyPath:@"properties.api-secret"]] : self.speechConfig.apiSecret;
 
-    /// MARK: NLU configuration
+    /// MARK: NLU
 
     self.speechConfig.nluModelPath = ([config valueForKeyPath:@"nlu.nlu-model-path"]) ? [RCTConvert NSString:[config valueForKeyPath:@"nlu.nlu-model-path"]] : self.speechConfig.nluModelPath;
     self.speechConfig.nluModelMetadataPath = ([config valueForKeyPath:@"nlu.nlu-metadata-path"]) ? [RCTConvert NSString:[config valueForKeyPath:@"nlu.nlu-metadata-path"]] : self.speechConfig.nluModelMetadataPath;

--- a/ios/RNSpokestack.m
+++ b/ios/RNSpokestack.m
@@ -208,7 +208,7 @@ RCT_EXPORT_METHOD(initialize:(NSDictionary *)config)
 
     self.speechConfig.tracing = ([config valueForKeyPath:@"properties.trace-level"]) ? [RCTConvert NSInteger:[config valueForKeyPath:@"properties.trace-level"]] : self.speechConfig.tracing;
     self.speechConfig.apiId = ([config valueForKeyPath:@"properties.api-id"]) ? [RCTConvert NSString:[config valueForKeyPath:@"properties.api-id"]] : self.speechConfig.apiId;
-    self.speechConfig.apiSecret = ([config valueForKeyPath:@"properties.api-id"]) ? [RCTConvert NSString:[config valueForKeyPath:@"properties.api-secret"]] : self.speechConfig.apiSecret;
+    self.speechConfig.apiSecret = ([config valueForKeyPath:@"properties.api-secret"]) ? [RCTConvert NSString:[config valueForKeyPath:@"properties.api-secret"]] : self.speechConfig.apiSecret;
 
     /// MARK: NLU
 


### PR DESCRIPTION
An example minimal config that will still allow for wakeword, asr, nlu, and tts:

```
      Spokestack.initialize({
        properties: {
          'spokestack-id': 'f0bc990c-e9db-4a0c-a2b1-6a6395a3d97e',
          'spokestack-secret': '5BD5483F573D691A15CFA493C1782F451D4BD666E39A9E7B2EBE287E6A72C6B6'
        },
        pipeline: {
          'profile': Spokestack.PipelineProfile.TFLITE_WAKEWORD_NATIVE_ASR,
          'wake-filter-path': filterModelPath,
          'wake-detect-path': detectModelPath,
          'wake-encode-path': encodeModelPath
        },
        nlu: {
          'nlu-model-path': nluModelPath,
          'nlu-metadata-path': nluMetadataPath,
          'wordpiece-vocab-path': nluVocabPath
        }
      })
```

All keys are optional, but building without a component and then attempting to access it at runtime will result in a native error.