### PR TITLE
fix(android): add proxies for real playback listeners

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -126,7 +126,7 @@ dependencies {
   // noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinx_version"
-  api 'io.spokestack:spokestack-android:10.0.0'
+  api 'io.spokestack:spokestack-android:11.0.0'
 
   // for TensorFlow Lite-powered wakeword detection and/or NLU
   implementation 'org.tensorflow:tensorflow-lite:2.3.0'

--- a/android/src/main/java/com/reactnativespokestack/SpokestackAdapter.kt
+++ b/android/src/main/java/com/reactnativespokestack/SpokestackAdapter.kt
@@ -55,9 +55,18 @@ class SpokestackAdapter(sendFunc:(event: String, data: WritableMap) -> Unit):io.
         reactEvent.putString("url", event.ttsResponse.audioUri.toString())
         sendEvent("synthesize", reactEvent)
       }
-      TTSEvent.Type.PLAYBACK_COMPLETE -> {
+      TTSEvent.Type.PLAYBACK_STARTED -> {
+        reactEvent.putBoolean("playing", true)
+        sendEvent("play", reactEvent)
+      }
+      TTSEvent.Type.PLAYBACK_STOPPED -> {
         reactEvent.putBoolean("playing", false)
         sendEvent("play", reactEvent)
+      }
+      TTSEvent.Type.PLAYBACK_COMPLETE -> {
+        // Playback is not pause-able in iOS
+        // so this event does not exist there.
+        Log.d(logTag, "Playback has completed")
       }
       TTSEvent.Type.ERROR -> {
         reactEvent.putString("error", "TTS error: " + event.error.localizedMessage)

--- a/android/src/main/java/com/reactnativespokestack/SpokestackModule.kt
+++ b/android/src/main/java/com/reactnativespokestack/SpokestackModule.kt
@@ -331,11 +331,6 @@ class SpokestackModule(private val reactContext: ReactApplicationContext): React
       val response = AudioResponse(uri)
       audioPlayer.audioReceived(response)
 
-      /* TODO: Change this to a playback started listener when spokestack-android supports it. */
-      val reactEvent = Arguments.createMap()
-      reactEvent.putBoolean("playing", true)
-      sendEvent("play", reactEvent)
-
       // Resolve RN promise
       promise.resolve(null)
       promises.remove(SpokestackPromise.SPEAK)

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -8,7 +8,7 @@ import React from 'react'
 import checkPermission from './checkPermission'
 
 const noTranscriptMessage =
-  'Press the listening button and speak to record a message for speech playback'
+  'Press the "Listen" button and speak to record a message for speech playback'
 
 export default function App() {
   const [listening, setListening] = React.useState(false)


### PR DESCRIPTION
This sends the `play` event based on `PLAYBACK_STARTED` and `PLAYBACK_STOPPED`.