### PR TITLE
fix: bump dependency to maven central version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -126,7 +126,7 @@ dependencies {
   // noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinx_version"
-  api 'io.spokestack:spokestack-android:11.0.0'
+  api 'io.spokestack:spokestack-android:11.0.2'
 
   // for TensorFlow Lite-powered wakeword detection and/or NLU
   implementation 'org.tensorflow:tensorflow-lite:2.3.0'


### PR DESCRIPTION
Since [JFrog is shutting down JCenter](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/), we've switched back to distributing the Android library on Maven Central, and we need to update every library dependent on it before JCenter becomes inaccessible. 11.0.2 is the first version on Central.